### PR TITLE
Github publish and package workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,131 @@
+name: Create Place Light Package
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  validate_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Validate json
+        uses: cardinalby/schema-validator-action@v3
+        with:
+          schema: https://raw.githubusercontent.com/FlayaN/LightPlacer-VR/refs/heads/json-schema/schema.json
+          file: package/**/LightPlacer/**/*.json
+      
+      - name: Install xmlstarlet
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xmlstarlet
+
+      - name: Download release archive
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: 'Mutagen-Modding/Spriggit'
+          latest: true
+          zipBall: true
+          fileName: 'SpriggitLinuxCLI.zip'
+          out-file-path: './downloads'
+      
+      - name: Extract archive
+        run: unzip ./downloads/SpriggitLinuxCLI.zip -d ./SpriggitCLI
+
+      - name: Prepare dist directory
+        run: |
+          if [ -d "dist" ]; then
+            rm -rf dist
+          else
+            mkdir dist
+          fi
+
+      - name: Copy package to dist excluding files
+        run: |
+          mkdir -p dist
+          rsync -av --exclude-from='exclusions.txt' package/ dist/
+
+      - name: Set permissions for Spriggit executable
+        run: chmod +x ./SpriggitCLI/Spriggit.CLI
+
+      - name: List directory contents for debugging
+        run: |
+          echo "Contents of ./SpriggitCLI:"
+          ls -l ./SpriggitCLI
+          echo "Contents of current directory:"
+          pwd
+          ls -l
+
+      - name: Run Spriggit fake deserialization until Spriggit bug is fixed
+        continue-on-error: true
+        run: |
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/PL - Bright" -o "./dist/PL - Bright.esp"
+
+      - name: Fake Spriggit until Spriggit bug is fixed
+        continue-on-error: true
+        run: |
+          cp /tmp/Spriggit/Translations/Spriggit.Json.Skyrim/0.36.13/Spriggit.Json.Skyrim /tmp/Spriggit/Translations/Spriggit.Json.Skyrim/0.36.13/Spriggit.Json.Skyrim.exe
+          chmod +x /tmp/Spriggit/Translations/Spriggit.Json.Skyrim/0.36.13/Spriggit.Json.Skyrim.exe
+      
+      - name: Run Spriggit templates deserialization
+        run: |
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/PL - Bright" -o "./dist/PL - Bright.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/PL - Dark" -o "./dist/PL - Dark.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/PL - Default" -o "./dist/PL - Default.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/PL - Nightmare" -o "./dist/PL - Nightmare.esp"
+      
+      - name: Run Spriggit main deserialization
+        run: |
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Placed Light" -o "./dist/Placed Light.esm"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Placed Light - Shadows and Ambient" -o "./dist/Placed Light - Shadows and Ambient.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Placed Light Exteriors" -o "./dist/Placed Light Exteriors.esp"
+          
+      - name: Run Spriggit misc deserialization
+        run: |          
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Misc Patches/Carbon LightBulbs Edit" -o "./dist/Misc Patches/Carbon LightBulbs Edit.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Misc Patches/NOTWL - Lanterns" -o "./dist/Misc Patches/NOTWL - Lanterns.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Misc Patches/Placed Light - Creation Club" -o "./dist/Misc Patches/Placed Light - Creation Club.esp"
+          ./SpriggitCLI/Spriggit.CLI deserialize -i "./Spriggit/Misc Patches/Placed Light Exteriors - NOTWL 3 patch" -o "./dist/Misc Patches/Placed Light Exteriors - NOTWL 3 patch.esp"
+
+      - name: List dist contents for debugging
+        run: |
+          echo "Contents of ./dist:"
+          ls -lR ./dist
+
+      # Extract version from the tag
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+     
+      - name: Get current  FOMOD version
+        id: fomod_version
+        run: | 
+          echo "FOMOD_VERSION=$(xmlstarlet sel -t -m '//Version' -v . ./package/fomod/info.xml)" >> $GITHUB_OUTPUT
+
+
+      - name: Update FOMOD XML with version
+        if: ${{ steps.fomod_version.outputs.FOMOD_VERSION !=  steps.extract_version.outputs.VERSION }}
+        run: | 
+          xmlstarlet ed --inplace -u '//Version' -v "${{ steps.extract_version.outputs.VERSION }}" ./package/fomod/info.xml
+          cp ./package/fomod/info.xml ./dist/fomod/info.xml
+          cat ./dist/fomod/info.xml
+
+      # Archive dist directory
+      - name: Archive dist directory
+        run: |          
+          cd ./dist ; zip -r ../downloads/PlacedLight.zip *
+
+      # Upload artifact
+      - name: Upload artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run:
+          gh release upload ${{ steps.extract_version.outputs.VERSION }} ./downloads/PlacedLight.zip

--- a/package/LightPlacer/Placed Light/Placed Light - Fires.json
+++ b/package/LightPlacer/Placed Light/Placed Light - Fires.json
@@ -74,7 +74,7 @@
           "light": "LightCampFire01",
           "radius": 512.0,
           "fade": 1.0,
-          "shadowDepthBias": 26.00,
+          "shadowDepthBias": 26.0,
           "flags": "IgnoreScale|Shadow"
         }
       }
@@ -121,7 +121,7 @@
           "light": "LightCampFire01",
           "radius": 400.0,
           "fade": 1.0,
-          "shadowDepthBias": 26.00,
+          "shadowDepthBias": 26.0,
           "flags": "IgnoreScale|Shadow"
         }
       }


### PR DESCRIPTION

When using the Create New Release on Github this deserialize plugins and then create a zip file and add to the release.

If the FOMOD info.xml version does NOT match the TAG specified when the release is created then that version will be updated first.

Note that the version in the repository is not updated.